### PR TITLE
feat: break infinity debug info

### DIFF
--- a/steamodded_metadata.lua
+++ b/steamodded_metadata.lua
@@ -52,6 +52,9 @@ end
 function SMODS.current_mod.load_mod_config() end
 function SMODS.current_mod.save_mod_config() end
 SMODS.current_mod.config_tab = Talisman.config_tab
+SMODS.current_mod.debug_info = {
+  ["Break Infinity"] = Talisman.config_file.break_infinity
+}
 --[[SMODS.Joker{
   key = "test",
   name = "Joker Test",


### PR DESCRIPTION
This adds debug info for the current break infinity option to the crash log.

![image](https://github.com/user-attachments/assets/6a9937a0-7901-46cf-bcd7-a46c00c2c6e2)

Nothing is shown when there is no break infinity method