### PR TITLE
Fix SMODS check

### DIFF
--- a/talisman.lua
+++ b/talisman.lua
@@ -14,7 +14,7 @@ if nativefs.read(lovely.mod_dir.."/Talisman/config.lua") then
       Talisman.config_file.break_infinity = "omeganum"
     end
 end
-if not SMODS or not SMODS.Atlas then
+if not SMODS then
   local createOptionsRef = create_UIBox_options
   function create_UIBox_options()
   contents = createOptionsRef()


### PR DESCRIPTION
Properly hides Talisman button in options menu when using steamodded.