### PR TITLE
Fix concat for bignum/omeganum, Vagabond crash

### DIFF
--- a/big-num/bignumber.lua
+++ b/big-num/bignumber.lua
@@ -328,6 +328,11 @@ function Big.parse(str)
     return Big:new(tonumber(parts[1]), math.floor(tonumber(parts[2]))):normalized()
 end
 
+function BigMeta.__concat(a, b)
+    a = Big:create(a)
+    return tostring(a) .. tostring(b)
+end
+
 --Adding things OmegaNum has that this doesn't...
 R = {}
 

--- a/big-num/omeganum.lua
+++ b/big-num/omeganum.lua
@@ -1334,6 +1334,11 @@ function OmegaMeta.__tostring(b)
     return number_format(b)
 end
 
+function OmegaMeta.__concat(a, b)
+    a = Big:create(a)
+    return tostring(a) .. tostring(b)
+end
+
 
 ---------------------------------------
 

--- a/lovely.toml
+++ b/lovely.toml
@@ -554,6 +554,20 @@ position = "at"
 payload = '''if self.ability.name == 'Bootstraps' and to_big(math.floor((G.GAME.dollars + (G.GAME.dollar_buffer or 0))/self.ability.extra.dollars)) >= to_big(1) then'''
 match_indent = true
 
+[[patches]]
+[patches.pattern]
+target = "card.lua"
+pattern = '''
+if self.ability.name == 'Vagabond' and #G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit then
+    if G.GAME.dollars <= self.ability.extra then
+'''
+position = "at"
+payload = '''
+if self.ability.name == 'Vagabond' and #G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit then
+    if to_big(G.GAME.dollars) <= to_big(self.ability.extra) then
+'''
+match_indent = true
+
 # for now, I'm letting dollar eval ignore bignum, I'll patch it later
 [[patches]]
 [patches.pattern]


### PR DESCRIPTION
I'm not 100% sure what happens of you try to concat the other way round (i.e. string..bignum), so that remains to be seen; maybe I should do some type checks here?