### PR TITLE
[I45] Use number-safe utility function for hand color

### DIFF
--- a/big-num/notations/Balatro.lua
+++ b/big-num/notations/Balatro.lua
@@ -13,33 +13,33 @@ function BalaNotation:new()
 end
 
 function BalaNotation:format(n, places)
-    local function e_ify(n)
-        if (n > 10^6) then
-            local exponent = math.floor(math.log(n,10))
-            local mantissa = n/10^exponent
-            mantissa = math.floor(mantissa*10^places+0.5)/10^places
-            return "("..exponent.."e"..mantissa..")"
+    --vanilla balatro number_format function basically
+    local function e_ify(num)
+        num = num and num:to_number() or 0
+        if num >= 10^6 then
+            local x = string.format("%.4g",num)
+            local fac = math.floor(math.log(tonumber(x), 10))
+            return string.format("%.3f",x/(10^fac))..'e'..fac
         end
-        if n < 1 then return 1 end
-        return n or "ERROR"
+        return string.format(num ~= math.floor(num) and (num >= 100 and "%.0f" or num >= 10 and "%.1f" or "%.2f") or "%.0f", num):reverse():gsub("(%d%d%d)", "%1,"):gsub(",$", ""):reverse()
     end
-    --The notation here is heavily based on Hyper-E notation.
+    --The notation here is Hyper-E notation, but with lowercase E.
     if to_big(n:log10()) < to_big(1000000) then
         --1.234e56789
         if n.m then --BigNum
             local mantissa = math.floor(n.m*10^places+0.5)/10^places
             local exponent = n.e
-            return mantissa.."e"..exponent
+            return mantissa.."e"..e_ify(exponent)
         elseif n.array[2] == 1 then --OmegaNum
             local mantissa = 10^(n.array[1]-math.floor(n.array[1]))
             mantissa = math.floor(mantissa*10^places+0.5)/10^places
             local exponent = math.floor(n.array[1])
-            return mantissa.."e"..exponent
+            return mantissa.."e"..e_ify(exponent)
         else
             local exponent = math.floor(math.log(n.array[1],10))
             local mantissa = n.array[1]/10^exponent
             mantissa = math.floor(mantissa*10^places+0.5)/10^places
-            return mantissa.."e"..exponent
+            return mantissa.."e"..e_ify(exponent)
         end
     elseif to_big(n:log10()) < to_big(10)^1000000 then
         --e1.234e56789
@@ -47,40 +47,36 @@ function BalaNotation:format(n, places)
             local exponent = math.floor(math.log(n.e,10))
             local mantissa = n.e/10^exponent
             mantissa = math.floor(mantissa*10^places+0.5)/10^places
-            return "e"..mantissa.."e"..exponent
+            return "e"..mantissa.."e"..e_ify(exponent)
         elseif n.array[2] == 2 then --OmegaNum
             local mantissa = 10^(n.array[1]-math.floor(n.array[1]))
             mantissa = math.floor(mantissa*10^places+0.5)/10^places
             local exponent = math.floor(n.array[1])
-            return "e"..mantissa.."e"..exponent
+            return "e"..mantissa.."e"..e_ify(exponent)
         else
             local exponent = math.floor(math.log(n.array[1],10))
             local mantissa = n.array[1]/10^exponent
             mantissa = math.floor(mantissa*10^places+0.5)/10^places
-            return "e"..mantissa.."e"..exponent
+            return "e"..mantissa.."e"..e_ify(exponent)
         end
     elseif not n.array or not (n.isFinite and n:isFinite()) then
         return "Infinity"
-    elseif n.array[2] == 3 and #n.array == 2 then
-        --ee1.234e56789
+    elseif n.array[2] and #n.array == 2 and n.array[2] <= 8 then
+        --eeeeeee1.234e56789
         local mantissa = 10^(n.array[1]-math.floor(n.array[1]))
         mantissa = math.floor(mantissa*10^places+0.5)/10^places
         local exponent = math.floor(n.array[1])
-        return "ee"..mantissa.."e"..exponent
-    elseif n.array[2] and #n.array == 2 and n.array[2] <= 8 then
-        --eeeeeeee56789
-        local exponent = math.floor(n.array[1])
-        return string.rep("e", n.array[2])..exponent
+        return string.rep("e", n.array[2]-1)..mantissa.."e"..e_ify(exponent)
     elseif #n.array < 8 then
         --e12#34#56#78
-        local r = "e"..e_ify(math.floor(n.array[1]*10^places+0.5)/10^places).."#"..n.array[2]
+        local r = "e"..e_ify(math.floor(n.array[1]*10^places+0.5)/10^places).."#"..e_ify(n.array[2])
         for i = 3, #n.array do
-            r = r.."#"..(n.array[i]+1)
+            r = r.."#"..e_ify(n.array[i]+1)
         end
         return r
     else
         --e12#34##5678
-        return "e"..e_ify(math.floor(n.array[1]*10^places+0.5)/10^places).."#"..n.array[#n.array].."##"..(#n.array-2)
+        return "e"..e_ify(math.floor(n.array[1]*10^places+0.5)/10^places).."#"..e_ify(n.array[#n.array]).."##"..e_ify(#n.array-2)
     end
 end
 

--- a/big-num/notations/Balatro.lua
+++ b/big-num/notations/Balatro.lua
@@ -15,7 +15,9 @@ end
 function BalaNotation:format(n, places)
     --vanilla balatro number_format function basically
     local function e_ify(num)
-        num = num and num:to_number() or 0
+        if type(num) == "table" then
+            num = num:to_number()
+        end
         if num >= 10^6 then
             local x = string.format("%.4g",num)
             local fac = math.floor(math.log(tonumber(x), 10))

--- a/lovely.toml
+++ b/lovely.toml
@@ -468,7 +468,7 @@ match_indent = true
 target = "functions/common_events.lua"
 pattern = "G.hand_text_area.hand_level.config.colour = G.C.HAND_LEVELS[math.min(vals.level, 7)]"
 position = "at"
-payload = "G.hand_text_area.hand_level.config.colour = G.C.HAND_LEVELS[to_big(math.min(vals.level, 7)):to_number()]"
+payload = "G.hand_text_area.hand_level.config.colour = G.C.HAND_LEVELS[to_number(to_big(math.min(vals.level, 7)))]"
 match_indent = true
 
 [[patches]]

--- a/lovely.toml
+++ b/lovely.toml
@@ -476,7 +476,7 @@ match_indent = true
 target = "functions/common_events.lua"
 pattern = "colours = {(G.GAME.hands[cfg.hand_type].level==1 and G.C.UI.TEXT_DARK or G.C.HAND_LEVELS[math.min(7, G.GAME.hands[cfg.hand_type].level)])}"
 position = "at"
-payload = "colours = {(to_big(G.GAME.hands[cfg.hand_type].level)==to_big(1) and G.C.UI.TEXT_DARK or G.C.HAND_LEVELS[to_big(math.min(7, G.GAME.hands[cfg.hand_type].level)):to_number()])}"
+payload = "colours = {(to_big(G.GAME.hands[cfg.hand_type].level)==to_big(1) and G.C.UI.TEXT_DARK or G.C.HAND_LEVELS[to_number(to_big(math.min(7, G.GAME.hands[cfg.hand_type].level)))])}"
 match_indent = true
 
 [[patches]]
@@ -484,7 +484,7 @@ match_indent = true
 target = "functions/UI_definitions.lua"
 pattern = '{n=G.UIT.C, config={align = "cm", padding = 0.01, r = 0.1, colour = G.C.HAND_LEVELS[math.min(7, G.GAME.hands[handname].level)], minw = 1.5, outline = 0.8, outline_colour = G.C.WHITE}, nodes={'
 position = "at"
-payload = '{n=G.UIT.C, config={align = "cm", padding = 0.01, r = 0.1, colour = G.C.HAND_LEVELS[to_big(math.min(7, G.GAME.hands[handname].level)):to_number()], minw = 1.5, outline = 0.8, outline_colour = G.C.WHITE}, nodes={'
+payload = '{n=G.UIT.C, config={align = "cm", padding = 0.01, r = 0.1, colour = G.C.HAND_LEVELS[to_number(to_big(math.min(7, G.GAME.hands[handname].level)))], minw = 1.5, outline = 0.8, outline_colour = G.C.WHITE}, nodes={'
 match_indent = true
 
 # money fixes


### PR DESCRIPTION
This should fix https://github.com/MathIsFun0/Talisman/issues/45.

Here is a video of me reproducing the bug:

https://youtu.be/7_W3sFC-OI0

The problem is in the line of code where it calculates what color to show for your currently selected hand. With BigNum and OmegaNum, the level is a Big type, so the method `:to_number` is available, so the Big returned by math.min is then converted back into a number so it can be used as an index into the HAND_COLORS table. However, if the number mode is set to Vanilla, both math.min and to_big return a plain number type, which cannot be indexed with the `to_number` function. The solution is to use the utility function `to_number` which can handle both Big and number inputs safely. It may also be reasonable to remove the call to `to_big` but that could have side effects, since that technically creates a new instance. I don't think it would, but it could be there for a reason.

Here is a video of this change working, and the color of the hand type updating appropriately:

https://youtu.be/h3WSuK0QJCc

The same issue happens in multiple places. I've updated this pattern for:
- The hand color when you're selecting a card
- The hand color in Run Info
- The colors set when localizing a Planet cards (specifically when you're not at level 1)

After making these three changes I went to play a few games of Vanilla (plus SMODS and Talisman) and experienced no crashes.