### PR TITLE
Fixing crashes and unexpected behavior resulting from latest changes

### DIFF
--- a/big-num/notations/Balatro.lua
+++ b/big-num/notations/Balatro.lua
@@ -23,7 +23,7 @@ function BalaNotation:format(n, places)
             local fac = math.floor(math.log(tonumber(x), 10))
             return string.format("%.3f",x/(10^fac))..'e'..fac
         end
-        return string.format(num ~= math.floor(num) and (num >= 100 and "%.0f" or num >= 10 and "%.1f" or "%.2f") or "%.0f", num):reverse():gsub("(%d%d%d)", "%1,"):gsub(",$", ""):reverse()
+        return string.format(num ~= math.floor(num) and (num >= 100 and "%.0f" or num >= 10 and "%.1f" or "%.2f") or "%.0f", num)
     end
     --The notation here is Hyper-E notation, but with lowercase E.
     if to_big(n:log10()) < to_big(1000000) then

--- a/big-num/notations/Balatro.lua
+++ b/big-num/notations/Balatro.lua
@@ -13,33 +13,33 @@ function BalaNotation:new()
 end
 
 function BalaNotation:format(n, places)
-    local function e_ify(n)
-        if (n > 10^6) then
-            local exponent = math.floor(math.log(n,10))
-            local mantissa = n/10^exponent
-            mantissa = math.floor(mantissa*10^places+0.5)/10^places
-            return "("..exponent.."e"..mantissa..")"
+    --vanilla balatro number_format function basically
+    local function e_ify(num)
+        num = num and num:to_number() or 0
+        if num >= 10^6 then
+            local x = string.format("%.4g",num)
+            local fac = math.floor(math.log(tonumber(x), 10))
+            return string.format("%.3f",x/(10^fac))..'e'..fac
         end
-        if n < 1 then return 1 end
-        return n or "ERROR"
+        return string.format(num ~= math.floor(num) and (num >= 100 and "%.0f" or num >= 10 and "%.1f" or "%.2f") or "%.0f", num):reverse():gsub("(%d%d%d)", "%1,"):gsub(",$", ""):reverse()
     end
-    --The notation here is heavily based on Hyper-E notation.
+    --The notation here is Hyper-E notation, but with lowercase E.
     if to_big(n:log10()) < to_big(1000000) then
         --1.234e56789
         if n.m then --BigNum
             local mantissa = math.floor(n.m*10^places+0.5)/10^places
             local exponent = n.e
-            return mantissa.."e"..exponent
+            return mantissa.."e"..e_ify(exponent)
         elseif n.array[2] == 1 then --OmegaNum
             local mantissa = 10^(n.array[1]-math.floor(n.array[1]))
             mantissa = math.floor(mantissa*10^places+0.5)/10^places
             local exponent = math.floor(n.array[1])
-            return mantissa.."e"..exponent
+            return mantissa.."e"..e_ify(exponent)
         else
             local exponent = math.floor(math.log(n.array[1],10))
             local mantissa = n.array[1]/10^exponent
             mantissa = math.floor(mantissa*10^places+0.5)/10^places
-            return mantissa.."e"..exponent
+            return mantissa.."e"..e_ify(exponent)
         end
     elseif to_big(n:log10()) < to_big(10)^1000000 then
         --e1.234e56789
@@ -47,40 +47,36 @@ function BalaNotation:format(n, places)
             local exponent = math.floor(math.log(n.e,10))
             local mantissa = n.e/10^exponent
             mantissa = math.floor(mantissa*10^places+0.5)/10^places
-            return "e"..mantissa.."e"..exponent
+            return "e"..mantissa.."e"..e_ify(exponent)
         elseif n.array[2] == 2 then --OmegaNum
             local mantissa = 10^(n.array[1]-math.floor(n.array[1]))
             mantissa = math.floor(mantissa*10^places+0.5)/10^places
             local exponent = math.floor(n.array[1])
-            return "e"..mantissa.."e"..exponent
+            return "e"..mantissa.."e"..e_ify(exponent)
         else
             local exponent = math.floor(math.log(n.array[1],10))
             local mantissa = n.array[1]/10^exponent
             mantissa = math.floor(mantissa*10^places+0.5)/10^places
-            return "e"..mantissa.."e"..exponent
+            return "e"..mantissa.."e"..e_ify(exponent)
         end
     elseif not n.array or not (n.isFinite and n:isFinite()) then
         return "Infinity"
-    elseif n.array[2] == 3 and #n.array == 2 then
-        --ee1.234e56789
+    elseif n.array[2] and #n.array == 2 and n.array[2] <= 8 then
+        --eeeeeee1.234e56789
         local mantissa = 10^(n.array[1]-math.floor(n.array[1]))
         mantissa = math.floor(mantissa*10^places+0.5)/10^places
         local exponent = math.floor(n.array[1])
-        return "ee"..mantissa.."e"..exponent
-    elseif n.array[2] and #n.array == 2 and n.array[2] <= 8 then
-        --eeeeeeee56789
-        local exponent = math.floor(n.array[1])
-        return string.rep("e", n.array[2])..exponent
+        return string.rep("e", n.array[2]-1)..mantissa.."e"..e_ify(exponent)
     elseif #n.array < 8 then
         --e12#34#56#78
-        local r = "e"..e_ify(math.floor(n.array[1]*10^places+0.5)/10^places).."#"..n.array[2]
+        local r = "e"..e_ify(math.floor(n.array[1]*10^places+0.5)/10^places).."#"..e_ify(n.array[2])
         for i = 3, #n.array do
-            r = r.."#"..(n.array[i]+1)
+            r = r.."#"..e_ify(n.array[i]+1)
         end
         return r
     else
         --e12#34##5678
-        return "e"..e_ify(math.floor(n.array[1]*10^places+0.5)/10^places).."#"..n.array[#n.array].."##"..(#n.array-2)
+        return "e"..e_ify(math.floor(n.array[1]*10^places+0.5)/10^places).."#"..e_ify(n.array[#n.array]).."##"..e_ify(#n.array-2)
     end
 end
 

--- a/big-num/notations/Balatro.lua
+++ b/big-num/notations/Balatro.lua
@@ -15,7 +15,9 @@ end
 function BalaNotation:format(n, places)
     --vanilla balatro number_format function basically
     local function e_ify(num)
-        num = num and num:to_number() or 0
+        if type(num) == "table" then
+            num = num:to_number()
+        end
         if num >= 10^6 then
             local x = string.format("%.4g",num)
             local fac = math.floor(math.log(tonumber(x), 10))

--- a/big-num/notations/Balatro.lua
+++ b/big-num/notations/Balatro.lua
@@ -23,7 +23,7 @@ function BalaNotation:format(n, places)
             local fac = math.floor(math.log(tonumber(x), 10))
             return string.format("%.3f",x/(10^fac))..'e'..fac
         end
-        return string.format(num ~= math.floor(num) and (num >= 100 and "%.0f" or num >= 10 and "%.1f" or "%.2f") or "%.0f", num)
+        return string.format(num ~= math.floor(num) and (num >= 100 and "%.0f" or num >= 10 and "%.1f" or "%.2f") or "%.0f", num):reverse():gsub("(%d%d%d)", "%1,"):gsub(",$", ""):reverse()
     end
     --The notation here is Hyper-E notation, but with lowercase E.
     if to_big(n:log10()) < to_big(1000000) then

--- a/big-num/omeganum.lua
+++ b/big-num/omeganum.lua
@@ -481,7 +481,7 @@ function Big:parse(input)
                 if (intPartLen - 1 >= LONG_STRING_MIN_LENGTH) then
                     b[1] = math.log10(b[1]) + log10LongString(string.sub(a[i], 1, intPartLen - 1))
                     b[2] = 1;
-                elseif ((a[i] ~= nil) and (a[i] ~= "")) then
+                elseif ((a[i] ~= nil) and (a[i] ~= "") and (tonumber(a[i]) ~= nil)) then
                     b[1] = b[1] * tonumber(a[i]);
                 end
             else

--- a/lovely.toml
+++ b/lovely.toml
@@ -1487,3 +1487,28 @@ payload = '''if type(_F.intensity) == "table" then
 end
 '''
 match_indent = true
+
+# G.funcs.evaluate_play()
+[[patches]]
+[patches.pattern]
+target = 'functions/state_events.lua'
+position = 'at'
+match_indent = true
+pattern = '''
+G.E_MANAGER:add_event(Event({
+    trigger = 'immediate',
+    func = function()
+        G.FUNCS.evaluate_play()
+        return true
+    end
+}))
+'''
+payload = '''
+G.E_MANAGER:add_event(Event({
+    trigger = 'immediate',
+    func = function()
+        G.FUNCS.evaluate_play(e)
+        return true
+    end
+}))
+'''

--- a/lovely.toml
+++ b/lovely.toml
@@ -1412,6 +1412,7 @@ G.E_MANAGER:add_event(Event({
 	trigger = 'after',delay = 0.4,
 '''
 match_indent = true
+
 [[patches]]
 [patches.pattern]
 target = 'functions/state_events.lua'
@@ -1428,5 +1429,61 @@ delay(0.3)
 return text, disp_text, poker_hands, scoring_hand, non_loc_disp_text, percent, percent_delta
 end
 function evaluate_play_after(text, disp_text, poker_hands, scoring_hand, non_loc_disp_text, percent, percent_delta)
+'''
+match_indent = true
+
+# Let shaders not use bignums
+[[patches]]
+[patches.pattern]
+target = 'engine/sprite.lua'
+pattern = "G.SHADERS[_shader]:send(v.name, v.val or (v.func and v.func()) or v.ref_table[v.ref_value])"
+position = 'at'
+payload = '''local val = v.val or (v.func and v.func()) or v.ref_table[v.ref_value]
+if type(val) == "table" and is_number(val) then
+	if val > to_big(1e300) then
+		val = 1e300
+	else
+		val = val:tonumber()
+	end
+end
+G.SHADERS[_shader]:send(v.name, val)'''
+match_indent = true
+
+# Let ambient sounds not use bignums
+[[patches]]
+[patches.pattern]
+target = 'functions/misc_functions.lua'
+pattern = "AC[k].vol = (not G.video_organ and G.STATE == G.STATES.SPLASH) and 0 or AC[k].vol and v.volfunc(AC[k].vol) or 0"
+position = 'after'
+payload = '''
+if type(AC[k].vol) == "table" then
+	if AC[k].vol > to_big(1e300) then
+		AC[k].vol = 1e300
+	else
+		AC[k].vol = AC[k].vol:to_number()
+	end
+end
+if type(AC[k].per) == "table" then
+	if AC[k].per > to_big(1e300) then
+		AC[k].per = 1e300
+	else
+		AC[k].per = AC[k].per:to_number()
+	end
+end
+'''
+match_indent = true
+
+[[patches]]
+[patches.pattern]
+target = 'functions/button_callbacks.lua'
+pattern = "_F.intensity = ((G.pack_cards and not G.pack_cards.REMOVED) or (G.TAROT_INTERRUPT)) and 0 or math.max(0., math.log(G.ARGS.score_intensity.earned_score, 5)-2)"
+position = 'after'
+payload = '''if type(_F.intensity) == "table" then
+	if _F.intensity > to_big(1e300) then
+		_F.intensity = 1e300
+	else
+		_F.intensity = _F.intensity:to_number()
+	end
+end
 '''
 match_indent = true

--- a/talisman.lua
+++ b/talisman.lua
@@ -328,7 +328,11 @@ if Talisman.config_file.break_infinity then
 
   local tsj = G.FUNCS.text_super_juice
   function G.FUNCS.text_super_juice(e, _amount)
-    if _amount > 2 then _amount = 2 end
+    if type(_amount) == 'table' then
+      if _amount > to_big(2) then _amount = 2 end
+    else
+      if _amount > 2 then _amount = 2 end
+    end
     return tsj(e, _amount)
   end
 

--- a/talisman.lua
+++ b/talisman.lua
@@ -178,6 +178,12 @@ if Talisman.config_file.break_infinity then
       return lenient_bignum(lg(x,y))
   end
 
+  function math.exp(x)
+    local big_e = to_big(2.718281828459045)
+    
+    return lenient_bignum(big_e:pow(x))
+  end 
+
   if SMODS then
     function SMODS.get_blind_amount(ante)
       local k = to_big(0.75)

--- a/talisman.lua
+++ b/talisman.lua
@@ -520,11 +520,11 @@ if not Talisman.F_NO_COROUTINE then
   --scoring coroutine
   local oldplay = G.FUNCS.evaluate_play
 
-  function G.FUNCS.evaluate_play()
+  function G.FUNCS.evaluate_play(...)
       G.SCORING_COROUTINE = coroutine.create(oldplay)
       G.LAST_SCORING_YIELD = love.timer.getTime()
       G.CARD_CALC_COUNTS = {} -- keys = cards, values = table containing numbers
-      local success, err = coroutine.resume(G.SCORING_COROUTINE)
+      local success, err = coroutine.resume(G.SCORING_COROUTINE, ...)
       if not success then
         error(err)
       end

--- a/talisman.lua
+++ b/talisman.lua
@@ -127,7 +127,7 @@ if Talisman.config_file.break_infinity then
       return mc(x)
   end
 
-  local function lenient_bignum(x)
+function lenient_bignum(x)
     if type(x) == "number" then return x end
     if to_big(x) < to_big(1e300) and to_big(x) > to_big(-1e300) then
       return x:to_number()

--- a/talisman.lua
+++ b/talisman.lua
@@ -143,6 +143,7 @@ if Talisman.config_file.break_infinity then
       if ret > to_big(1e300) then return 1e300 end
       return ret:to_number()
     end
+    return ret
   end
 
   local gftsj = G.FUNCS.text_super_juice

--- a/talisman.lua
+++ b/talisman.lua
@@ -394,7 +394,9 @@ function is_number(x)
 end
 
 function to_big(x, y)
-  if Big and Big.m then
+  if type(x) == 'string' and x == "0" then --hack for when 0 is asked to be a bignumber need to really figure out the fix
+    return 0
+  elseif Big and Big.m then
     return Big:new(x,y)
   elseif Big and Big.array then
     local result = Big:create(x)


### PR DESCRIPTION
# Issue
Game crash upon trying to compute BigNums with some jokers

# Result
* Added missing return value for non-BigNums to `score_number_scale` as this was causing blind requirements to not show up and other things to break
* Added lovely patch for the call to `G.funcs.evaluate_play` to take in an argument `e` when it's being added as an event.
* Added ability for arguments to be passed into concurrent call of `G.funcs.evaluate_play`
* Added `math.exp()` override function to use bigNum calculation. 
    * This was causing `Cryptid.log_random` to return `inf` at large values of `x`
    * Uses `lenient_bignum()` to allow it to return regular numbers for functions expecting it to (non-joker scaling stuff)
* ~~Removed commas from `BalaNotation` as these would somehow get stored in the games data and break `Parse`~~
    * Found the core issue of this within `Parse` 
* Fixed `super_juice` to allow for BigNum input
* Made `lenient_bignum` a global function for use in Cryptid
    
# Requirements
None

# Modified Files
`lovely.toml`
* Added patch for call to `G.funcs.evaulate_play` when added as an event

`talsiman.lua`
* Added missing return value to `score_number_scale`
* Added `math.exp()` override
* Added arguments being passed in to the concurrent call of `G.funcs.evaluate_play`
* Fixed `super_juice` to allow for BigNum input
* Made `lenient_bignum` a global function for use in Cryptid

`big-num/omeganum.lua`
* Fixed commas breaking `Parse`

~~`notaions/Balatro.lua`~~
* ~~Removed commas from BalaNotation~~
 