### PR TITLE
(perceived) fix for decimal hand levels

### DIFF
--- a/talisman.lua
+++ b/talisman.lua
@@ -474,7 +474,7 @@ function tal_uht(config, vals)
         else
             G.GAME.current_round.current_hand.hand_level = ' '..localize('k_lvl')..tostring(vals.level)
             if is_number(vals.level) then
-                G.hand_text_area.hand_level.config.colour = G.C.HAND_LEVELS[type(vals.level) == "number" and math.floor(math.min(vals.level, 7)) or math.floor(to_big(math.min(vals.level, 7)):to_number())]
+                G.hand_text_area.hand_level.config.colour = G.C.HAND_LEVELS[type(vals.level) == "number" and math.floor(math.min(vals.level, 7)) or math.floor(to_big(math.min(vals.level, 7))):to_number()]
             else
                 G.hand_text_area.hand_level.config.colour = G.C.HAND_LEVELS[1]
             end


### PR DESCRIPTION
we forgot to clamp the maximum value of the vals.level when it's a regular number. 

I also decided to `math.floor` the values too, since we would probably run into the same issues of passing a wrong index in at low decimal levels (say 6.9 or 4.20) as those aren't actual indices into the `G.C.HAND_LEVELS` table, resulting in a `nil` value. 